### PR TITLE
Add AM/PM time format support

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -75,6 +75,9 @@ const applySettings = async () => {
   }
 
   // Apply military time setting to the app (if needed)
+  if (mainWindow) {
+    mainWindow.webContents.send('apply-settings', { militaryTime });
+  }
 };
 
 app


### PR DESCRIPTION
Related to #3

Implement AM/PM time format display and settings in the app.

* **Clock Component**:
  - Update to display time in AM/PM format based on settings.
  - Add state and effect to load settings for military time.

* **Alarms Component**:
  - Update to provide an option to set AM/PM format for alarms.
  - Add state and effect to load settings for military time.
  - Modify alarm time display to use AM/PM format if settings indicate.

* **Main Process**:
  - Update `applySettings` function to apply AM/PM time format settings.
  - Send settings to renderer process to apply military time setting.

